### PR TITLE
Port to Moo and MooX::Types::MooseLike

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,8 @@ WriteMakefile(
 
     PREREQ_PM => {
         'Test::More' => 0,
-        'Moose' => 0,
+        'Moo' => 0,
+        'MooX::Types::MooseLike' => 0,
         'Email::Sender' => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,9 +21,9 @@ WriteMakefile(
 
     PREREQ_PM => {
         'Test::More' => 0,
-        'Moo' => 0,
-        'MooX::Types::MooseLike' => 0,
-        'Email::Sender' => 0,
+        'Moo' => "1.000008",
+        'MooX::Types::MooseLike' => "0.15",
+        'Email::Sender' => "1.300000",
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Email-Sender-Transport-Redirect-*' },

--- a/lib/Email/Sender/Transport/Redirect.pm
+++ b/lib/Email/Sender/Transport/Redirect.pm
@@ -30,7 +30,8 @@ the original recipients.
 
 =cut
 
-use Moose;
+use Moo;
+use MooX::Types::MooseLike::Base qw/ArrayRef Str/;
 
 extends 'Email::Sender::Transport::Wrapper';
 
@@ -40,14 +41,14 @@ has 'redirect_address' => (is => 'ro',
 
 has 'redirect_headers' => (
                            is  => 'ro',
-                           isa => 'ArrayRef',
+                           isa => ArrayRef,
                            default    => sub { [qw/To Cc/] },
 );
 
 has 'intercept_prefix' => (
                            is => 'ro',
-                           isa => 'Str',
-                           default => sub { 'X-Intercepted-'}
+                           isa => Str,
+                           default => 'X-Intercepted-',
                           );
 
 around send_email => sub {


### PR DESCRIPTION
Email::Transport has been using Moo since the start of 2013 so about time we got this switched.
