### PR TITLE
bump dep on Moo to 1.001000 closes GH#4

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,7 @@ WriteMakefile(
 
     PREREQ_PM => {
         'Test::More' => 0,
-        'Moo' => "1.000008",
+        'Moo' => "1.001000",
         'MooX::Types::MooseLike' => "0.15",
         'Email::Sender' => "1.300000",
     },


### PR DESCRIPTION
Commit cc1ad3c6037e2a4073a17dc4d225c59c15bd7aff changed scalar defaults
from subs to simple scalars which requires Moo v1.001000.

from Moo changes:
 1.001000
- non-ref default values are allowed without using a sub
